### PR TITLE
Legacy Soundtrack plus TTS prototype

### DIFF
--- a/area/dreamZan.py
+++ b/area/dreamZan.py
@@ -7,6 +7,7 @@ import rngTrack
 import targetPathing
 import vars
 import xbox
+import tts
 
 game_vars = vars.vars_handle()
 
@@ -44,6 +45,12 @@ def new_game(Gamestate):
                     lastMessage = 4
                     print("New Game is selected. Starting game.")
                 xbox.menu_b()
+        memory.main.click_to_diag_progress(6)
+        if game_vars.useLegacySoundtrack():
+            tts.message("Setting legacy soundtrack")
+            memory.main.wait_frames(20)
+            xbox.tap_down()
+            memory.main.wait_frames(20)
         memory.main.click_to_diag_progress(7)
     else:  # Load Game
         while not memory.main.save_menu_open():
@@ -110,7 +117,7 @@ def listen_story():
                 print("Tidus name complete.")
 
                 checkpoint += 1
-            # elif checkpoint == 7 and gameVars.csr():
+            # elif checkpoint == 7 and game_vars.csr():
             #    checkpoint = 9
             elif checkpoint == 8:
                 while memory.main.user_control():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.22.3
 ReadWriteMemory==0.1.5
 vgamepad==0.0.8
+pyttsx3==2.90

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,6 @@
+import pyttsx3
+engine = pyttsx3.init()
+
+def message(value:str):
+    engine.say(value)
+    engine.runAndWait()

--- a/vars.py
+++ b/vars.py
@@ -28,6 +28,7 @@ class AllVars:
         )
         self.perfectAeonKills = False  # Before YuYevon, True is slower but more swag.
         self.attemptDjose = True  # Try Djose skip? (not likely to succeed)
+        self.legacySoundtrack = True
 
         # ----Blitzball
         self.blitzWinValue = True  # No default value required
@@ -78,6 +79,9 @@ class AllVars:
         # coderwilson main PC
         self.savePath = "C:/Users/Thomas/Documents/SQUARE ENIX/FINAL FANTASY X&X-2 HD Remaster/FINAL FANTASY X/"
 
+    def useLegacySoundtrack(self):
+        return self.legacySoundtrack
+    
     def try_djose_skip(self):
         return self.attemptDjose
 


### PR DESCRIPTION
For both of these additions, if vars > self.legacySoundtrack is set to True, we will use the legacy soundtrack. We also will report this via text to speech. Of note, new library is now needed via "pip install pyttsx3"