### PR TITLE
Fixed logging

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,9 +29,11 @@ vars:
 
 
   # Cosmetics / Other
+  original_soundtrack     : False  # Sets to original or arranged soundtrack.
+  force_loop              : False  # After game is finished, start again on next seed.
+
+logging:
   color_log               : False  # Colors the console output. May not work on some systems
   verbosity               : DEBUG  # Verbosity of log messages in the console.
                                    # These are the valid levels: DEBUG, MANIP, INFO, WARNING, ERROR, CRITICAL
                                    # Full log will always be available in a file.
-  original_soundtrack     : False  # Sets to original or arranged soundtrack.
-  force_loop              : False  # After game is finished, start again on next seed.

--- a/log_init.py
+++ b/log_init.py
@@ -76,8 +76,9 @@ def initialize_logging():
 
     # Get the visible log level for the console logger from config.yaml
     config_data = config.open_config()
-    console_log_level = config_data.get("verbosity", "DEBUG")
-    color_log = config_data.get("color_log", False)
+    config_logging = config_data.get("logging", {})
+    console_log_level = config_logging.get("verbosity", "DEBUG")
+    color_log = config_logging.get("color_log", False)
 
     # Set up the console logger
     console = logging.StreamHandler()


### PR DESCRIPTION
Put the logging related stuff in its own section of `config.yaml`, instead of as a part of `vars`.

This allows the `color_log` and `verbosity` flags to be used again.