### PR TITLE
Mac Temple pathing patch

### DIFF
--- a/area/kilika.py
+++ b/area/kilika.py
@@ -7,6 +7,7 @@ import menu
 import pathing
 import save_sphere
 import vars
+import logs
 import xbox
 from paths import Kilika1, Kilika2, Kilika3, KilikaTrials
 from players import Kimahri, Tidus, Wakka, Yuna

--- a/area/mac_temple.py
+++ b/area/mac_temple.py
@@ -177,15 +177,25 @@ def seymour_fight():
     xbox.name_aeon("Shiva")
 
     memory.main.await_control()
-    FFXC.set_movement(-1, -1)
-    memory.main.wait_frames(30 * 0.4)
-    FFXC.set_movement(-1, 0)
-    memory.main.await_event()
+    targets = [
+        [6,-85],
+        [2,-128],
+        [2,-160]
+    ]
+    
+    checkpoint = 0
+    while memory.main.get_map() == 80:
+        if pathing.set_movement(targets[checkpoint]):
+            checkpoint += 1
+    
     FFXC.set_neutral()
 
 
 def trials():
+    logger.debug("Start of trials.")
     memory.main.await_control()
+    #FFXC.set_movement(0,1)
+    #memory.main.wait_frames(15)
 
     checkpoint = 0
     while memory.main.get_map() != 153:


### PR DESCRIPTION
This will make it so the path does not break at 2x and 4x speed before starting the trials. No promises after the trials have been started. Also, a quick import in Kilika for a missing file.